### PR TITLE
Fixed typo: startTime -> start_time

### DIFF
--- a/lib/video.js
+++ b/lib/video.js
@@ -770,8 +770,8 @@ module.exports = function (filePath, settings, infoConfiguration, infoFile) {
 		resetCommands(this);
 		
 		// Adding commands to the list
-		if (settings.startTime)
-			this.addCommand('-ss', settings.startTime);
+		if (settings.start_time)
+			this.addCommand('-ss', settings.start_time);
 		if (settings.duration_time)
 			this.addCommand('-t', settings.duration_time);
 		if (settings.frame_rate)


### PR DESCRIPTION
It was preventing fnExtractFrameToJPG to take into account the
start_time
