### PR TITLE
Added experimental flags to watermarking

### DIFF
--- a/lib/video.js
+++ b/lib/video.js
@@ -849,6 +849,9 @@ module.exports = function (filePath, settings, infoConfiguration, infoFile) {
 		
 		// Add destination file path to the command list
 		setOutput(newFilepath);
+		
+	        commands.push('-strict');
+        	commands.push('-2')
 
 		// Executing the commands list
 		return execCommand.call(this, callback);


### PR DESCRIPTION
Since the watermarking function resets commands then it needs to add experimental flags to work on the unix version of ffmpeg with mobile videos.

Fixes error :
The encoder 'aac' is experimental but experimental codecs are not enabled, add '-strict -2' if you want to use it