### PR TITLE
fnExtractFrameToJPG enable file names to digits. #5

### DIFF
--- a/lib/video.js
+++ b/lib/video.js
@@ -762,7 +762,12 @@ module.exports = function (filePath, settings, infoConfiguration, infoFile) {
 			}
 		}
 		// At the filename will added the number of the frame
-		settings.file_name = path.basename(settings.file_name, path.extname(settings.file_name)) + '_%d.jpg';
+		settings.file_name = path.basename(settings.file_name, path.extname(settings.file_name));
+		if (settings.file_name.match(/%[0-9]{1,2}d/)) {
+			settings.file_name += '.jpg';
+		} else {
+			settings.file_name += '_%d.jpg';
+		}
 		
 		// Create the directory to save the extracted frames
 		utils.mkdir(destinationFolder, 0777);


### PR DESCRIPTION
Hi.
I tried to fix #5.
If you specify a file name in such a code, "my_frame_001.jpg, my_frame_002.jpg, ..." files are created.

```javascript
         video.fnExtractFrameToJPG ('/path/to/save_your_frames', {
             frame_rate: 1,
             number: 5,
             file_name: 'my_frame_%03d'
         }
```