### PR TITLE
add quotes for output

### DIFF
--- a/lib/video.js
+++ b/lib/video.js
@@ -59,7 +59,7 @@ module.exports = function (filePath, settings, infoConfiguration, infoFile) {
 	 * Set the output path
 	 */
 	var setOutput = function (path) {
-		output = path;
+		output = utils.addQuotes(path);
 	}
 
 	/*********************/


### PR DESCRIPTION
when there is space in output, program will fail

the version published to npm is behind master, `inputs` is not quoted either