### PR TITLE
Increase node child process maxBuffer setting

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -12,6 +12,9 @@ module.exports.exec = function (commands, settings, callback) {
 	var finalCommand = commands.join(" ");
 	// Create the timeoutId for stop the timeout at the end the process
 	var timeoutID = null;
+	
+	settings.maxBuffer = 1024*1024*1024*5 // 5 GB, default of child_process lib is : 1024*1024 bytes
+	
 	// Exec the command
 	var process = exec(finalCommand, settings, function (error, stdout, stderr) {
 		// Clear timeout if 'timeoutID' are setted


### PR DESCRIPTION
Prevents the child process from be killed for long running ffmpeg jobs.

Implemented fix as described in #81 