### PR TITLE
Do not add quotes for input filename, breaks plenty of file paths

### DIFF
--- a/lib/ffmpeg.js
+++ b/lib/ffmpeg.js
@@ -62,7 +62,7 @@ var ffmpeg = function (/* inputFilepath, settings, callback */) {
 		// New 'promise' instance 
 		var deferred = when.defer();
 		// Make the call to retrieve information about the ffmpeg
-		utils.exec([ffmpeg.bin,'-i', utils.addQuotes(fileInput),'2>&1'], settings, function (error, stdout, stderr) {
+		utils.exec([ffmpeg.bin,'-i', fileInput,'2>&1'], settings, function (error, stdout, stderr) {
 			// Perse output for retrieve the file info
 			var filename		= /from \'(.*)\'/.exec(stdout) || []
 			  , title			= /(INAM|title)\s+:\s(.+)/.exec(stdout) || []

--- a/lib/video.js
+++ b/lib/video.js
@@ -557,7 +557,7 @@ module.exports = function (filePath, settings, infoConfiguration, infoFile) {
 		}
 		// Create a copy of the commands list
 		var finalCommands = ['ffmpeg -i']
-			.concat(inputs.map(utils.addQuotes).join(' -i '))
+			.concat(inputs.join(' -i '))
 			.concat(commands.join(' '))
 			.concat(filtersComlpex.length > 0 ? ['-filter_complex "'].concat(filtersComlpex.join(', ')).join('') + '"' : [])
 			.concat([output]);


### PR DESCRIPTION
As per https://github.com/damianociarla/node-ffmpeg/issues/78 there are problems whenever spaces (and probably many other characters) are used in filenames. I don't see the need to "add quotes" for file paths, particularly if these are coming from a properly-formed string as would be the case with `path.resolve("./some/folder/file with spaces etc.mp4"`.

In any case, the `utils.addQuotes` function currently uses `JSON.stringify` which is surely not intended for this use case. We don't want JSON, we want a path to pass to the command line.

I don't have access Windows machine now so I can't test whether this breaks anything on Windows, but I would assume `path.resolve` should give a perfectly valid filename path as a string, too.