### PR TITLE
Make ffmpeg executable path configurable

### DIFF
--- a/lib/configs.js
+++ b/lib/configs.js
@@ -2,6 +2,7 @@
  * Basic configuration
  */
 module.exports = function () {
+	this.bin = 'ffmpeg';
 	this.encoding	= 'utf8';
 	this.timeout	= 0;
 	this.maxBuffer	= 200 * 1024

--- a/lib/ffmpeg.js
+++ b/lib/ffmpeg.js
@@ -17,7 +17,7 @@ var ffmpeg = function (/* inputFilepath, settings, callback */) {
 		// Instance the new arrays for the format
 		var format = { modules : new Array(), encode : new Array(), decode : new Array() };
 		// Make the call to retrieve information about the ffmpeg
-		utils.exec(['ffmpeg','-formats','2>&1'], settings, function (error, stdout, stderr) {
+		utils.exec([settings.bin,'-formats','2>&1'], settings, function (error, stdout, stderr) {
 			// Get the list of modules
 			var configuration = /configuration:(.*)/.exec(stdout);
 			// Check if exists the configuration
@@ -62,7 +62,7 @@ var ffmpeg = function (/* inputFilepath, settings, callback */) {
 		// New 'promise' instance 
 		var deferred = when.defer();
 		// Make the call to retrieve information about the ffmpeg
-		utils.exec(['ffmpeg','-i',fileInput,'2>&1'], settings, function (error, stdout, stderr) {
+		utils.exec([settings.bin,'-i',fileInput,'2>&1'], settings, function (error, stdout, stderr) {
 			// Perse output for retrieve the file info
 			var filename		= /from \'(.*)\'/.exec(stdout) || []
 			  , title			= /(INAM|title)\s+:\s(.+)/.exec(stdout) || []

--- a/lib/video.js
+++ b/lib/video.js
@@ -551,7 +551,7 @@ module.exports = function (filePath, settings, infoConfiguration, infoFile) {
 		// Building the value for return value. Check if the callback is not a function. In this case will created a new instance of the deferred class
 		var deferred = typeof callback != 'function' ? when.defer() : { promise : null };
 		// Create a copy of the commands list
-		var finalCommands = ['ffmpeg -i']
+		var finalCommands = [settings.bin,'-i']
 			.concat(inputs.join(' -i '))
 			.concat(commands.join(' '))
 			.concat(filtersComlpex.length > 0 ? ['-filter_complex "'].concat(filtersComlpex.join(', ')).join('') + '"' : [])


### PR DESCRIPTION
It seems like this package is abandoned but it still works better for me than the alternative for the project I'm currently working on. One thing I needed to be able to do is change the ffmpeg executable path so that it can work with ffmpeg-static, it seems like some effort was made to make this configurable (c099e37388b90b1965594b16b27c8d1f04cd2559) however it was still hard-coded for the video object. So I went a different route.

The `bin` is now a setting that can be configured like this:

```js
const pathToFfmpeg = require('ffmpeg-static')
const ffmpeg = require('ffmpeg')

const video = await new ffmpeg(filePath, { bin: pathToFfmpeg })
```

I cut my branch from the 46e8bb5cfa9d30e0430465d57be8ea7804f2f438 commit as that is the latest version that is published to NPM (I also couldn't get what's currently on the repo to work).

Even though this package is abandoned I figured I'd still put up the PR just in case anyone else runs into this issue.