### PR TITLE
Fixed small typo in video.js

### DIFF
--- a/lib/video.js
+++ b/lib/video.js
@@ -395,7 +395,7 @@ module.exports = function (filePath, settings, infoConfiguration, infoFile) {
 				if (options.video.hasOwnProperty('codec'))
 					this.addCommand('-vcodec', options.video.codec);
 				if (options.video.hasOwnProperty('bitrate'))
-					this.addCommand('-b', parseInt(options.video.bitrate, 10) + 'kb');
+					this.addCommand('-b', parseInt(options.video.bitrate, 10) + 'k');
 				if (options.video.hasOwnProperty('framerate'))
 					this.addCommand('-r', parseInt(options.video.framerate, 10));
 				if (options.video.hasOwnProperty('startTime'))


### PR DESCRIPTION
Removed "b" from "kb" in line 398, letting .setVideoBitRate() work